### PR TITLE
[maintenance] Update puppeteer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^8.2.0",
-    "puppeteer": "^5.3.1",
+    "puppeteer": "^23.7.1",
     "showdown": "^1.9.1",
     "showdown-highlight": "^2.1.5"
   }

--- a/scripts/generate-pdf.js
+++ b/scripts/generate-pdf.js
@@ -32,8 +32,8 @@ const footer = '<div></div>';
     await page.addStyleTag({path: path.resolve(__dirname, '../styles/styles.css')});
 
     // Give time to load images, etc
-    await page.waitForTimeout(3000);
-  
+    await new Promise(r => setTimeout(r, 3000));
+
     // Generate PDF file
     await page.pdf({
       format: 'Letter',


### PR DESCRIPTION
Installing was giving issues on a m3 macOS machine due to Puppeteer being unable to install chromium correctly. Upgrading Puppeteer fixed the issue.